### PR TITLE
News history (#44)

### DIFF
--- a/news_archive.html
+++ b/news_archive.html
@@ -61,15 +61,56 @@
             	<div class="container">
             		<div class="row">
             			<div class="col-md-12">
-            				<h1 class="main-page-header">Old news</h1>
-            				<h3 class="main-sub-header">UPDATE page subheader</h3>
+            				<h1 class="main-page-header">ReproNim News Archive</h1>
             			</div>
             		</div><!-- row -->
             		<div class="row">
             			<div class="col-md-12">
 
-                    <p>UPDATE content</p>
+                    
+                            
+                            <h3>Past Events and Activities</h3>
+<p>
+<ul>
+<li> Congratulations to our Inaugural 2019-2020 class of ReproNim/INCF Fellows!</li>
+                           
+   
+<li> ReproNim is launching a new Training Fellowship!</li>
+<ul>
+<li> Gain conceptual and practical training in reproducible neuroimaging topics
+<li> Share expertise and expand your professional network for future collaborations
+<li> Establish mentorship ties for the next year with ReproNim faculty
+<li> Applications being accepted for 2019 Fellows until February 26, 2019
+<li> Program Announcement and Application here: <a href="https://docs.google.com/forms/d/e/1FAIpQLSdHhe-mYSqwqgpHQc8u-LnW3iSgVsKXuXE7I0_RBa_LI6xIYw/viewform">Link</a>
+<li> Sponsored jointly with the International Neuroinformatics Coordinating Factility (INCF) <a href="https://www.incf.org/">Link</a></li>    
+</ul>
+   
+<li> ReproNim Tools Currently Featured on the Big Data U's website! <a href="https://bigdatau.ini.usc.edu/">Link</a></li>
 
+
+<li> Society for Neuroscience Events:
+<ul>
+<li> SfN Neuroinformatics Social, Tuesday November 6, 2018. <a href="https://www.sfn.org/Meetings/Neuroscience-2018/Sessions-and-Events/SfN-Sponsored-Socials#Tuesday,-November-06,-2018-6:45PM-8:45PM">Link</a>
+<li> SfN Workshop FAIR Neuroscience: Sharing and Collaborating for Reproducible Neuroscience, November 5, 2018. <a href="https://www.sfn.org/Meetings/Neuroscience-2018/Sessions-and-Events/Professional-Development-Workshops#Monday,-November-05,-2018">Link</a>
+<li> SfN Worskhop How a Journal Handles Your Paper, including Reproducibility Issues, November 4, 2018. <a href="https://www.sfn.org/Meetings/Neuroscience-2018/Sessions-and-Events/Professional-Development-Workshops#Sunday,-November-04,-2018">Link</a>
+<li> Reproducible NeuroImaging Training November 2-3, 2018, before SfN: <a href="https://tinyurl.com/repronim-train">Link</a>
+</ul>   
+ 
+<li> 5 Steps to Reproducible Neuroimaging Draft <a href="http://www.reproducibleimaging.org/5steps">here</a></li>
+
+<li> Reproducible NeuroImaging Training November 2-3, 2018 before SFN: <a href="https://tinyurl.com/repronim-train">Link</a></li>    
+
+<li> OHBM Hackathon TrainTrack: <a href="https://ohbm.github.io/hackathon2018/">Link</a></li>
+<li> OHBM Sunday All-day Hands-On Training Course in Reproducible Neuroimaging: <a href="https://github.com/ReproNim/ohbm2018-training">Link</a></li>
+<li> ReproNim Activities at OHBM 2018 in Singapore: <a href="https://docs.google.com/document/d/1y7HSYe5q2WkA9QM_UJuOBX8AA8f_uvXeANdluzHZD14/edit?usp=sharing">Link</a></li>    
+
+<li> Slides from the SOBP 2018 symposium Reproducibility in Psychiatric Neuroimaging: Big Data for Big Problems posted here: <a href="https://osf.io/b73mz/wiki/home/">Link</a></li>    
+    
+<li> There will be a Reproducible Neuroimaging Training Workshop held just prior to the Society for Neuroscience meeting in Washington DC, November 10-11, 2017. See <a href="https://tinyurl.com/repronim-sfn17">https://tinyurl.com/repronim-sfn17</a> for more details</li>   
+  
+    </p>
+
+    
           </div>
         </div>
       </div>
@@ -79,9 +120,9 @@
         <div class="container">
             <div class="row">
                 <div class="col-sm-4">
-                    <h3>UPDATE section header</h3>
+                    <h3> </h3>
 <p>
-UPDATE section content
+
 </p>
 
             	</div>


### PR DESCRIPTION
* first draft update for news archive

* single line tweak to test indenting 

remove a single <ul> to see effects on indentation (or not) following the nested Fellowship items

* two changes for line spacing and indentations

only remove two different ul operations

* two line changes for line spacing & formatting

remove two ul operations, to remove extra line of space, while maintaining left margin alignment

* change main page header

change from 'Old News' to 'ReproNim News Archive' - purely a wording change, but in the process, see whether centering changes or not

* change section header

change header from 'News Archive' to Past Events and Activities- purely a wording change, but will also be a test of whether spacing is maintained

* remove the UPDATE line, text only

strictly a wording deletion, of only the text on this line (71) without removing the start and end paragraph operations, to see whether space allocation is preserved

* remove paragraph at line 71

just remove start and stop of paragraph, which is currently empty, to see if it affects allocation of blank vertical white space on page

* remove text only for update page subheader

remove words only, leave rest of line intact- to remove text not needed, and see whether spacing/formatting is affected in the process

* Remove 2 update statements

remove text only for update statements that = extraneous wording at bottom of viewable page- but leave rest of each line (124, 126) intact

* removed empty header